### PR TITLE
Fix PageComponents deleting all fields when updating a Component

### DIFF
--- a/app/Component.php
+++ b/app/Component.php
@@ -28,6 +28,7 @@ class Component extends Model
     {
         $comp_fields = ComponentField::where([
             'component_id' => $this->id,
+            'status' => 0,
         ])->get();
 
         return $comp_fields;

--- a/app/ComponentField.php
+++ b/app/ComponentField.php
@@ -11,22 +11,28 @@ class ComponentField extends Model
     // tilkobling til ett image
     public function image()
     {
-       return  $this->belongsTo('App\Image');
+        return $this->belongsTo('App\Image');
     }
 
     // Kobling til en link
     public function link()
     {
-      return $this->belongsTo('App\Link');
+        return $this->belongsTo('App\Link');
     }
 
     public function component()
     {
-      return $this->belongsTo('App\Component');
-   }
+        return $this->belongsTo('App\Component');
+    }
 
-   public function field()
-   {
-      return $this->belongsTo('App\Field');
-   }
+    public function field()
+    {
+        return $this->belongsTo('App\Field');
+    }
+
+    public function mark_for_deletion()
+    {
+        $this->status = 1;
+        $this->save();
+    }
 }

--- a/app/Http/Controllers/ComponentController.php
+++ b/app/Http/Controllers/ComponentController.php
@@ -91,7 +91,7 @@ class ComponentController extends Controller
         $component->save();
 
         foreach ($component->component_fields as $component_field) {
-            $component_field->delete();
+            $component_field->mark_for_deletion();
         }
 
         foreach ($request->fields as $field) {
@@ -154,7 +154,7 @@ class ComponentController extends Controller
         $component->save();
 
         foreach ($component->component_fields as $component_field) {
-            $component_field->delete();
+            $component_field->mark_for_deletion();
         }
 
         foreach ($request->fields as $field) {

--- a/app/Http/Controllers/PageController.php
+++ b/app/Http/Controllers/PageController.php
@@ -178,6 +178,8 @@ class PageController extends Controller
             }
         }
 
+        Page::run_cleanup();
+
         return redirect()->route('pages.edit', $page)->with('success', 'Page er oppdatert');
     }
 

--- a/app/Page.php
+++ b/app/Page.php
@@ -184,6 +184,20 @@ class Page extends Model
         }
     }
 
+    public static function run_cleanup()
+    {
+        $page_component_field_ids = PageComponent::pluck('component_field_id')->toArray();
+        $component_fields = ComponentField::where('status', 1)->get();
+
+        foreach ($component_fields as $component_field) {
+            // Check if the component_field is being used by any pages
+            if (!in_array($component_field->id, $page_component_field_ids)) {
+                // Comp field is not being used, so let's delete it
+                $component_field->delete();
+            }
+        }
+    }
+
     public function getSlugAttribute()
     {
         return Str::slug($this->title);

--- a/app/PageComponent.php
+++ b/app/PageComponent.php
@@ -24,7 +24,7 @@ class PageComponent extends Model
         $component_field = ComponentField::find($this->component_field_id);
         $field = null;
 
-        if ($component_field !== null) {
+        if ($component_field !== null && $component_field->status === 0) {
             $field = Field::find($component_field->id);
         }
 

--- a/database/migrations/2019_02_04_091557_create_component_fields_table.php
+++ b/database/migrations/2019_02_04_091557_create_component_fields_table.php
@@ -1,8 +1,8 @@
 <?php
 
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
 class CreateComponentFieldsTable extends Migration
 {

--- a/database/migrations/2019_04_21_111358_add_status_column_to_component_fields_table.php
+++ b/database/migrations/2019_04_21_111358_add_status_column_to_component_fields_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddStatusColumnToComponentFieldsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('component_fields', function (Blueprint $table) {
+            $table->tinyInteger('status')->unsigned()->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('component_fields', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+}


### PR DESCRIPTION
Previously when a Component was updated, all the PageComponent's fields would be removed. Now they remain until they are no longer in use by any page